### PR TITLE
change defaults to use NTP servers for all OS and not just the Ubuntu NTP servers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 ntp_driftfile: /var/lib/ntp/drift
-ntp_server: [0.ubuntu.pool.ntp.org, 1.ubuntu.pool.ntp.org]
+ntp_server: [0.pool.ntp.org, 1.pool.ntp.org]
 ntp_restrict:
   - "restrict -4 default kod notrap nomodify nopeer noquery"
   - "restrict -6 default kod notrap nomodify nopeer noquery"


### PR DESCRIPTION
change defaults to use NTP servers for all OS and not just the Ubuntu NTP servers
